### PR TITLE
Simplify the init script

### DIFF
--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -141,7 +141,7 @@ git remote remove github-origin &>/dev/null
 git remote rename origin github-origin &>/dev/null
 
 #git remote remove origin
-git remote add origin https://PAT:$ADO_PAT_INPUT@$CLEAN_ADO_ORIGIN
+git remote add origin https://PAT:$ADO_PAT@$CLEAN_ADO_ORIGIN
 
 GIT_DEFAULT_BRANCH_NAME=$(git remote show origin | grep "HEAD branch\: " | sed 's/HEAD branch\: //g' | xargs)
 

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -88,105 +88,50 @@ if [ -z "$ADO_REPO_URL" ]; then
 
 fi
 
+if [ -z "$ADO_PAT"]; then
+    echo -e $PALETTE_CYAN"Please provide your ADO PAT\n"$PALETTE_RESET
 
+    # reading the PAT
+    unset CHARCOUNT
+    unset ADO_PAT_INPUT
+    PROMPT=" ↳ PAT code[R/W] + packaging[R]: "
 
+    stty -echo
 
-unset AZ_DO_USERNAME_SUFFIX;
-if [ -z "$AZ_DO_USERNAME" ]; then
-    AZ_DO_USERNAME_SUFFIX=""
-else
-    AZ_DO_USERNAME_SUFFIX=$PALETTE_CYAN"(➥ to reuse *$AZ_DO_USERNAME*)"$PALETTE_RESET
-fi
-
-echo -e $PALETTE_CYAN"\n- Please provide your ADO username\n"$PALETTE_RESET
-
-printf " ↳ ADO Username$AZ_DO_USERNAME_SUFFIX: $PALETTE_PURPLE"
-
-read AZ_DO_USERNAME_INPUT
-
-echo -e " $PALETTE_RESET"
-
-if [ -z "$AZ_DO_USERNAME_INPUT" ]; then
-    if [ -z "$AZ_DO_USERNAME" ]; then
-        echo -e $PALETTE_RED"  🗿 No name - no fame"$PALETTE_RESET
-        exit 1
-    else
-        AZ_DO_USERNAME_INPUT=$AZ_DO_USERNAME
-        echo -e $PALETTE_DIM"  * reusing *$AZ_DO_USERNAME_INPUT* as ADO username.\n"$PALETTE_RESET
-    fi
-fi
-
-IFS=@ read -r username domain <<< "$AZ_DO_USERNAME_INPUT"
-if [ ! -z "$domain" ]; then
-    AZ_DO_USERNAME_INPUT="$username"
-    echo -e $PALETTE_DIM"  * using *$AZ_DO_USERNAME_INPUT* as ADO username.\n"$PALETTE_RESET
-fi
-
-if [ "$AZ_DO_USERNAME" != "$AZ_DO_USERNAME_INPUT" ]; then
-    export AZ_DO_USERNAME=$AZ_DO_USERNAME_INPUT
-
-    echo "export AZ_DO_USERNAME=$AZ_DO_USERNAME" >> $CACHE_FILE_PATH
-fi
-
-
-
-
-
-
-
-
-echo -e $PALETTE_CYAN"- Thanks, *$AZ_DO_USERNAME*! Please provide your ADO PAT\n"$PALETTE_RESET
-
-unset AZ_DO_PASSWORD_SUFFIX;
-if [ -z "$ADO_PAT" ]; then
-    AZ_DO_PASSWORD_SUFFIX=""
-else
-    AZ_DO_PASSWORD_SUFFIX=$PALETTE_CYAN"(➥ to reuse old PAT)"$PALETTE_RESET
-fi
-
-# reading the PAT
-unset CHARCOUNT
-unset ADO_PAT_INPUT
-PROMPT=" ↳ PAT code[R/W] + packaging[R]$AZ_DO_PASSWORD_SUFFIX: "
-
-stty -echo
-
-CHARCOUNT=0
-while IFS= read -p "$PROMPT" -r -s -n 1 CHAR
-do
-    # Enter - accept password
-    if [[ $CHAR == $'\0' ]] ; then
-        break
-    fi
-
-    # Backspace
-    if [[ $CHAR == $'\177' ]] ; then
-        if [ $CHARCOUNT -gt 0 ] ; then
-            CHARCOUNT=$((CHARCOUNT-1))
-            PROMPT=$'\b \b'
-            ADO_PAT_INPUT="${PASSWORD%?}"
-        else
-            PROMPT=''
+    CHARCOUNT=0
+    while IFS= read -p "$PROMPT" -r -s -n 1 CHAR
+    do
+        # Enter - accept password
+        if [[ $CHAR == $'\0' ]] ; then
+            break
         fi
-    else
-        CHARCOUNT=$((CHARCOUNT+1))
-        PROMPT='*'
-        ADO_PAT_INPUT+="$CHAR"
-    fi
-done
 
-stty echo
-echo -e " "$PALETTE_RESET
+        # Backspace
+        if [[ $CHAR == $'\177' ]] ; then
+            if [ $CHARCOUNT -gt 0 ] ; then
+                CHARCOUNT=$((CHARCOUNT-1))
+                PROMPT=$'\b \b'
+                ADO_PAT_INPUT="${PASSWORD%?}"
+            else
+                PROMPT=''
+            fi
+        else
+            CHARCOUNT=$((CHARCOUNT+1))
+            PROMPT='*'
+            ADO_PAT_INPUT+="$CHAR"
+        fi
+    done
 
-# check if PAT set
-if [ -z ${ADO_PAT_INPUT} ]; then
-    if [ -z "$ADO_PAT" ]; then
+    stty echo
+    echo -e " "$PALETTE_RESET
+
+    # check if PAT set
+    if [ -z ${ADO_PAT_INPUT} ]; then
         echo -e $PALETTE_RED"\n  🐢  No PAT - Zero FLOPS per watt\n"$PALETTE_RESET
         exit 1
-    else
-        ADO_PAT_INPUT=$ADO_PAT
-        echo -e $PALETTE_DIM"\n  * reusing the old PAT."$PALETTE_RESET
     fi
+
+    ADO_PAT=$ADO_PAT_INPUT
 fi
 
 EMPTY_STRING=""
@@ -196,7 +141,7 @@ git remote remove github-origin &>/dev/null
 git remote rename origin github-origin &>/dev/null
 
 #git remote remove origin
-git remote add origin https://$AZ_DO_USERNAME:$ADO_PAT_INPUT@$CLEAN_ADO_ORIGIN
+git remote add origin https://PAT:$ADO_PAT_INPUT@$CLEAN_ADO_ORIGIN
 
 GIT_DEFAULT_BRANCH_NAME=$(git remote show origin | grep "HEAD branch\: " | sed 's/HEAD branch\: //g' | xargs)
 

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -21,6 +21,10 @@ if [ -f ~/.cs-environment ]; then
     source ~/.cs-environment
 fi
 
+if [ -n $ADO_PAT ]; then
+    NONINTERACTIVE=true
+fi
+
 GREETINGS=("Bonjour" "Hello" "Salam" "Привет" "Вітаю" "Hola" "Zdravo" "Ciao" "Salut" "Hallo" "Nǐ hǎo" "Xin chào" "Yeoboseyo" "Aloha" "Namaskaram" "Wannakam" "Dzień dobry")
 GREETING=${GREETINGS[$RANDOM % ${#GREETINGS[@]} ]}
 
@@ -40,18 +44,15 @@ echo -e $PALETTE_WHITE"\n
 
 echo -e $PALETTE_GREEN"\n\n     🖖 👽  $GREETING, Codespacer 👽 🖖\n"$PALETTE_RESET
 
-sleep 1s
+if [ -z "$NONINTERACTIVE" ]; then
+    sleep 1s
+fi
 
 echo -e $PALETTE_PURPLE"\n🏃 Lets setup the Codespace"$PALETTE_RESET
 
-sleep 0.25s
-
-
-
-
-
-
-
+if [ -z "$NONINTERACTIVE" ]; then
+    sleep 0.25s
+fi
 
 if [ -z "$ADO_REPO_URL" ]; then
 
@@ -229,9 +230,6 @@ if ! [ -z $NUGET_FILE_PATH ] 2> /dev/null && [ -f $NUGET_FILE_PATH ]; then
   " > ~/.nuget/NuGet/NuGet.Config
 fi
 
-
-
-
 # get the .npmrc file path
 unset NPMRC_FILE_PATH
 # 1. check the NPMRC_CONFIG_FILE_PATH variable set by the uer first
@@ -273,10 +271,6 @@ $CLEAN_FEED_URL:email=npm requires email to be set but doesn't use the value\n
 fi
 
 echo -e $FEEDS_STRING >> ~/.npmrc
-
-
-
-
 
 cd $CODESPACE_DEFAULT_PATH
 

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -132,7 +132,7 @@ if [ -z "$ADO_PAT" ]; then
         exit 1
     fi
 
-    ADO_PAT=$ADO_PAT_INPUT
+    export ADO_PAT=$ADO_PAT_INPUT
 fi
 
 EMPTY_STRING=""
@@ -157,10 +157,6 @@ git branch --track github-main
 git pull origin $GIT_DEFAULT_BRANCH_NAME:$GIT_DEFAULT_BRANCH_NAME --force --no-tags
 
 git checkout $GIT_DEFAULT_BRANCH_NAME &>/dev/null
-
-if [ "$ADO_PAT" != "$ADO_PAT_INPUT" ]; then
-    export ADO_PAT=$ADO_PAT_INPUT
-fi
 
 export ADO_PAT_BASE64=$(echo -n $ADO_PAT | base64)
 # replace env variable reference in the .npmrc

--- a/.codespaces/init-ado-repo.sh
+++ b/.codespaces/init-ado-repo.sh
@@ -88,7 +88,7 @@ if [ -z "$ADO_REPO_URL" ]; then
 
 fi
 
-if [ -z "$ADO_PAT"]; then
+if [ -z "$ADO_PAT" ]; then
     echo -e $PALETTE_CYAN"Please provide your ADO PAT\n"$PALETTE_RESET
 
     # reading the PAT


### PR DESCRIPTION
* Remove prompts for ADO username since we don't need the username anywhere in the auth flows. Hardcode the value to PAT in the git remote auth.
* Make the `ADO_PAT` portion non-interactive if the `ADO_PAT` environment variable already exists via user settings.
* Remove artificial sleeps in non-interactive mode
* Clean up some extra blank lines and other small style fixes

These changes together make the script non-interactive if you have an `ADO_PAT` variable pre-defined.